### PR TITLE
Fix: Update import path for StartScreenPrompt in config.ts

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,4 +1,4 @@
-import { StartScreenPrompt } from "@openai/chatkit";
+import { StartScreenPrompt } from "@openai/chatkit-react";
 
 export const WORKFLOW_ID = process.env.NEXT_PUBLIC_CHATKIT_WORKFLOW_ID?.trim() ?? "";
 


### PR DESCRIPTION
Fixed incorrect import for `StartScreenPrompt` in `config.ts`.
Updated path from `@openai/chatkit` to `@openai/chatkit-react` to prevent build errors.
