### PR TITLE
Bump chatkit-react version; harden dev script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "openai-chatkit-starter-app",
       "version": "0.1.0",
       "dependencies": {
-        "@openai/chatkit-react": "^0",
+        "@openai/chatkit-react": ">=1.1.1 <=2.0.0",
         "next": "^15.5.4",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
@@ -968,18 +968,16 @@
       }
     },
     "node_modules/@openai/chatkit": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@openai/chatkit/-/chatkit-0.0.0.tgz",
-      "integrity": "sha512-9YomebDd2dpWFR3s1fiEtNknXmEC8QYt//2ConGjr/4geWdRqunEpO+i7yJXYEGLJbkmB4lxwKmbwWJA4pvpSg==",
-      "license": "MIT"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@openai/chatkit/-/chatkit-1.0.0.tgz",
+      "integrity": "sha512-BlRu1UMz29z01bn0D2nA5lgSeo0Eu/5uNdGUMKchoFEDHWQ8ViCHDRFO45O6FT/cdqhXbYZOzIrjUryq6djk4w=="
     },
     "node_modules/@openai/chatkit-react": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@openai/chatkit-react/-/chatkit-react-0.0.0.tgz",
-      "integrity": "sha512-ppoAKiWKUJGIlKuFQ0mgPRVMAAjJ+PonAzdo1p7BQmTEZtwFI8vq6W7ZRN2UTfzZZIKbJ2diwU6ePbYSKsePuQ==",
-      "license": "MIT",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@openai/chatkit-react/-/chatkit-react-1.1.1.tgz",
+      "integrity": "sha512-sbYZBqLkx5nEIRmBFXJ8OCsRB+0II1eu/9QSVJP4T73PdAsggTMPfxw8FUGioFFJcYrNVoFvYaBFHZVUC71jtw==",
       "dependencies": {
-        "@openai/chatkit": "0.0.0"
+        "@openai/chatkit": "1.0.0"
       },
       "peerDependencies": {
         "react": ">=18",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "unset OPENAI_API_KEY && next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"
   },
   "dependencies": {
-    "@openai/chatkit-react": "^0",
+    "@openai/chatkit-react": ">=1.1.1 <2.0.0",
     "next": "^15.5.4",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"


### PR DESCRIPTION
* Bump `@openai/chatkit-react` version
* Update `npm run dev` to always use the openai api key specified in `.env.local`