### PR TITLE
Add endpoint to create ChatKit session

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,0 +1,22 @@
+from fastapi import FastAPI
+from openai import OpenAI
+import os
+
+app = FastAPI()
+client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+WORKFLOW_ID = "wf_690f89e6ad3481908e6b3aaf13d73648023a37965a01916e"
+
+@app.post("/api/chatkit/session")
+def create_chatkit_session():
+    """
+    Creates a new ChatKit session for the BizScanFix Tier 1 Audit.
+    The client_secret is returned for frontend initialization.
+    """
+    session = client.chatkit.sessions.create(
+        workflow={"id": WORKFLOW_ID},
+        # Optional: tag for analytics or session tracking
+        metadata={"source": "bizscanfix_web_portal"}
+    )
+
+    return {"client_secret": session.client_secret}


### PR DESCRIPTION
This pull request introduces a new FastAPI endpoint that initializes a ChatKit session for the BizScanFix Tier 1 Audit workflow.

Key details:
• Adds `/api/chatkit/session` route to the backend (FastAPI)
• Uses OpenAI Python SDK to create a new ChatKit session
• Passes the workflow ID for the BizScanFix Tier 1 Audit
• Returns the short-lived `client_secret` to the frontend for ChatKit initialization
• No persistent storage; session tokens are ephemeral

This enables the frontend ChatKit widget to connect securely to our OpenAI workflow and start live audit sessions directly from the BizScanFix dashboard.
