### PR TITLE
Add compatibility to the WSL

### DIFF
--- a/managed-chatkit/package.json
+++ b/managed-chatkit/package.json
@@ -6,7 +6,7 @@
     "frontend": "npm --prefix frontend install && npm --prefix frontend run dev",
     "frontend:build": "npm --prefix frontend install && npm --prefix frontend run build",
     "frontend:lint": "npm --prefix frontend install && npm --prefix frontend run lint",
-    "backend": "./backend/scripts/run.sh"
+    "backend": "bash -lc './backend/scripts/run.sh'"
   },
   "devDependencies": {
     "concurrently": "^9.1.2"


### PR DESCRIPTION
# Problem
The backend script is a Bash script (uses bash features and shebang). If a non-Bash shell runs it, it doesn’t understand ./run.sh, fails early, and produces “'.' is not recognized as an internal or external command”.

# Solution
Changing the npm script to bash -lc './backend/scripts/run.sh' pins the shell to Bash, so:
◦  ./path execution works
◦  Bash features (set -euo pipefail, source, etc.) work
◦  Behavior is consistent in WSL, Git Bash, and Unix shells

# What changed
•  In managed-chatkit/package.json: scripts.backend from ./backend/scripts/run.sh to bash -lc './backend/scripts/run.sh'.

# Alternatives you could use instead
•  Add an .npmrc with script-shell set to bash globally for the repo.
•  Change the script to a POSIX-sh compatible script and call sh ./backend/scripts/run.sh (only if it truly needs no Bash features).