### PR TITLE
fix: replace param "item" with "input_user_message"

### DIFF
--- a/chatkit/backend/app/server.py
+++ b/chatkit/backend/app/server.py
@@ -38,7 +38,7 @@ class StarterChatServer(ChatKitServer[dict[str, Any]]):
     async def respond(
         self,
         thread: ThreadMetadata,
-        item: UserMessageItem | None,
+        input_user_message: UserMessageItem | None,
         context: dict[str, Any],
     ) -> AsyncIterator[ThreadStreamEvent]:
         items_page = await self.store.load_thread_items(


### PR DESCRIPTION
fix the parameter name mismatch:
```
Method "respond" overrides class "ChatKitServer" in an incompatible manner
  Parameter 3 name mismatch: base parameter is named "input_user_message", override parameter is named "item" (basedpyright reportIncompatibleMethodOverride)
```